### PR TITLE
Fix Magento setup:upgrade error

### DIFF
--- a/code/magento-os/lightna-frontend/Plugin/DbSchema.php
+++ b/code/magento-os/lightna-frontend/Plugin/DbSchema.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lightna\Frontend\Plugin;
+
+use Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaReaderInterface;
+
+class DbSchema
+{
+    public function afterReadTables(DbSchemaReaderInterface $subject, array $tables): array
+    {
+        foreach ($tables as $key => $table) {
+            if (str_starts_with($table, 'lightna_')) {
+                unset($tables[$key]);
+            }
+        }
+
+        return $tables;
+    }
+}

--- a/code/magento-os/lightna-frontend/etc/di.xml
+++ b/code/magento-os/lightna-frontend/etc/di.xml
@@ -11,4 +11,7 @@
             <argument name="storage" xsi:type="object">Lightna\Frontend\Model\Session\Storage</argument>
         </arguments>
     </type>
+    <type name="Magento\Framework\Setup\Declaration\Schema\Db\DbSchemaReaderInterface">
+        <plugin name="lightna_db_schema" type="Lightna\Frontend\Plugin\DbSchema"/>
+    </type>
 </config>


### PR DESCRIPTION
Fix Magento setup:upgrade error: Cannot process definition to array for type enum.
Solution: ignore lightna_* tables by Magento