### PR TITLE
Improve Plugins: Currently it's not possible to extend init method as…

### DIFF
--- a/code/lightna/lightna-session/App/Plugin/App.php
+++ b/code/lightna/lightna-session/App/Plugin/App.php
@@ -12,7 +12,7 @@ class App extends ObjectA
 {
     protected Session $session;
 
-    public function process(Closure $proceed): void
+    public function processExtended(Closure $proceed): void
     {
         $this->session->prolong();
         $proceed();

--- a/code/lightna/magento-os-backend/App/Plugin/App.php
+++ b/code/lightna/magento-os-backend/App/Plugin/App.php
@@ -12,7 +12,7 @@ class App extends ObjectA
 {
     protected Config $config;
 
-    public function renderNoRoute(): Closure
+    public function renderNoRouteExtended(): Closure
     {
         $config = $this->config;
 

--- a/code/lightna/magento-os-backend/App/Plugin/App/Index/Changelog/Handler.php
+++ b/code/lightna/magento-os-backend/App/Plugin/App/Index/Changelog/Handler.php
@@ -12,7 +12,7 @@ class Handler extends ObjectA
 {
     protected Product $productQuery;
 
-    public function addIndexBatchDependencies(Closure $proceed, array &$indexBatch): void
+    public function addIndexBatchDependenciesExtended(Closure $proceed, array &$indexBatch): void
     {
         $productIds = $indexBatch['product'] ?? [];
         $parentIds = $productIds ? $this->productQuery->getParentsBatch($productIds) : [];

--- a/code/lightna/magento-os-backend/App/Plugin/App/Scope.php
+++ b/code/lightna/magento-os-backend/App/Plugin/App/Scope.php
@@ -18,7 +18,7 @@ class Scope extends ObjectA
         $this->list = $this->db->fetchCol($this->getListSelect());
     }
 
-    public function getList(): array
+    public function getListExtended(): array
     {
         return $this->list;
     }

--- a/code/lightna/magento-os-demo/Plugin/App/Layout.php
+++ b/code/lightna/magento-os-demo/Plugin/App/Layout.php
@@ -9,7 +9,7 @@ use Lightna\Engine\App\ObjectA;
 
 class Layout extends ObjectA
 {
-    public function renderPage(Closure $proceed): void
+    public function renderPageExtended(Closure $proceed): void
     {
         $proceed();
         template('server-time.phtml');


### PR DESCRIPTION
… it's used to create plugin instance and plugin might require own init method. Solution: Every extended method need to have "Extended" in its name